### PR TITLE
Allow traversal of non-secure notes

### DIFF
--- a/bw_add_sshkeys.py
+++ b/bw_add_sshkeys.py
@@ -137,6 +137,9 @@ def add_ssh_keys(session, items, keyname):
         except IndexError:
             logging.warning('No "%s" field found for item %s', keyname, item['name'])
             continue
+        except KeyError as e:
+            logging.debug('No key "%s" found in item %s - skipping', e.args[0], item['name'])
+            continue
         logging.debug('Private key file declared')
 
         try:


### PR DESCRIPTION
This PR will cleanly ignore any extraneous Logins, Cards, etc which exist within the same Folder as your bitwarden Secure Notes and ssh-keys.

The way I've been using this script is by keeping **all** project specific details within a Bitwarden Folder (ie: `bw_add_sshkeys.py -f ProjectA`).  This includes logins and ssh keys, without this PR you'll get an uncaught exception about the 'fields' key missing (as this doesn't exist in Logins, Cards, etc).