### PR TITLE
New Features

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,25 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Aktuelle Datei",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal",
+            "args": [
+                "--remove",
+                "--session", 
+                "<redacted>",
+                "-c",
+                "keyname",
+                "-f",
+                "ssh-keys"
+            ],
+            "justMyCode": true
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -28,3 +28,4 @@ Fetches SSH keys stored in Bitwarden vault and adds them to `ssh-agent`.
 * `--foldername`/`-f` - Folder name to use to search for SSH keys _(default: ssh-agent)_
 * `--customfield`/`-c` - Custom field name where private key filename is stored _(default: private)_
 * `--passphrasefield`/`-p` - Custom field name where passphrase for the key is stored _(default: passphrase)_
+* `--session`/`-s` - session key of bitwarden

--- a/bw_add_sshkeys.py
+++ b/bw_add_sshkeys.py
@@ -56,12 +56,13 @@ def cli_supports(feature: str) -> bool:
     return False
 
 
-def get_session() -> str:
+def get_session(session: str) -> str:
     """
     Function to return a valid Bitwarden session
     """
     # Check for an existing, user-supplied Bitwarden session
-    session = os.environ.get('BW_SESSION', '')
+    if not session:
+        session = os.environ.get('BW_SESSION', '')
     if session:
         logging.debug('Existing Bitwarden session found')
         return session
@@ -101,6 +102,7 @@ def get_folders(session: str, foldername: str) -> str:
         stdout=subprocess.PIPE,
         universal_newlines=True,
         check=True,
+        encoding = "utf-8",
     )
 
     folders = json.loads(proc_folders.stdout)
@@ -128,6 +130,7 @@ def folder_items(session: str, folder_id: str) -> List[Dict[str, Any]]:
         stdout=subprocess.PIPE,
         universal_newlines=True,
         check=True,
+        encoding = "utf-8",
     )
 
     data: List[Dict[str, Any]] = json.loads(proc_items.stdout)
@@ -270,6 +273,12 @@ if __name__ == '__main__':
             default='passphrase',
             help='custom field name where key passphrase is stored',
         )
+        parser.add_argument(
+            '-s',
+            '--session',
+            default='',
+            help='session key of bitwarden',
+        )
 
         return parser.parse_args()
 
@@ -289,7 +298,7 @@ if __name__ == '__main__':
 
         try:
             logging.info('Getting Bitwarden session')
-            session = get_session()
+            session = get_session(args.session)
             logging.debug('Session = %s', session)
 
             logging.info('Getting folder list')

--- a/bw_add_sshkeys.py
+++ b/bw_add_sshkeys.py
@@ -7,12 +7,17 @@ import argparse
 import json
 import logging
 import os
+import sys
 import subprocess
 from typing import Any, Callable, Dict, List, Optional
+from cryptography.hazmat.primitives.serialization import load_ssh_private_key
+from cryptography.hazmat.primitives.serialization import Encoding
+from cryptography.hazmat.primitives.serialization import PublicFormat
 
 from pkg_resources import parse_version
 
-
+##################################################
+### Main Functions
 def memoize(func: Callable[..., Any]) -> Callable[..., Any]:
     """
     Decorator function to cache the results of another function call
@@ -28,21 +33,7 @@ def memoize(func: Callable[..., Any]) -> Callable[..., Any]:
 
     return memoized_func
 
-
-@memoize
-def bwcli_version() -> str:
-    """
-    Function to return the version of the Bitwarden CLI
-    """
-    proc_version = subprocess.run(
-        ['bw', '--version'],
-        stdout=subprocess.PIPE,
-        universal_newlines=True,
-        check=True,
-    )
-    return proc_version.stdout
-
-
+# maybe obsolete
 @memoize
 def cli_supports(feature: str) -> bool:
     """
@@ -138,42 +129,67 @@ def folder_items(session: str, folder_id: str) -> List[Dict[str, Any]]:
     return data
 
 
-def add_ssh_keys(
+def manage_ssh_keys(
     session: str,
-    items: List[Dict[str, Any]],
-    keyname: str,
-    pwkeyname: str,
+    args: argparse.Namespace,
+    items: List[Dict[str, Any]]
 ) -> None:
     """
     Function to attempt to get keys from a vault item
     """
-    for item in items:
+    privatekey_found = False
+    for index,item in enumerate(items, start=1):
         try:
-            private_key_file = [
-                k['value'] for k in item['fields'] if k['name'] == keyname
-            ][0]
+            # IF we have a name specified, skip until the entry is found
+            #
+            if not args.entryname is None:
+
+                if item['name'] == args.entryname:
+                    logging.info("Requested Entry %s found", item['name'])
+                else:
+                    logging.debug("Skipping entry %s as it was not requested", item['name'])
+                    if not privatekey_found and index >= len(items):
+                        logging.error("Sadly the requested entry could not be found. Exiting now...")
+                    continue
+                
+                if args.assume_keyname:
+                    private_key_file = args.entryname
+                    privatekey_found = True
+                else:
+                    private_key_file = [
+                        k['value'] for k in item['fields'] if k['name'] == args.customfield
+                    ][0]
+                    privatekey_found = True
+            else:
+                private_key_file = [
+                    k['value'] for k in item['fields'] if k['name'] == args.customfield
+                ][0]
         except IndexError:
-            logging.warning('No "%s" field found for item %s', keyname, item['name'])
+            logging.info('No "%s" field found for item %s - skipping', args.customfield, item['name'])
             continue
         except KeyError as error:
-            logging.debug(
-                'No key "%s" found in item %s - skipping', error.args[0], item['name']
-            )
+            logging.debug('No key "%s" found in item %s - skipping', error.args[0], item['name'])
+            if not args.assume_keyname:
+                logging.error("No additional fields are specified for your entryname. Exiting now...")
+                break
             continue
         logging.debug('Private key file declared')
 
         private_key_pw = None
-        try:
-            private_key_pw = [
-                k['value'] for k in item['fields'] if k['name'] == pwkeyname
-            ][0]
-            logging.debug('Passphrase declared')
-        except IndexError:
-            logging.warning('No "%s" field found for item %s', pwkeyname, item['name'])
-        except KeyError as error:
-            logging.debug(
-                'No key "%s" found in item %s - skipping', error.args[0], item['name']
-            )
+        if not args.password_as_key_pass:
+            try:
+                private_key_pw = [
+                    k['value'] for k in item['fields'] if k['name'] == args.passphrasefield
+                ][0]
+                logging.debug('Passphrase declared')
+            except IndexError:
+                logging.warning('No "%s" field found for item %s - if ssh key needs password this is an error!', args.passphrasefield, item['name'])
+            except KeyError as error:
+                logging.debug(
+                    'No key "%s" found in item %s - skipping', error.args[0], item['name']
+                )
+        else:
+            private_key_pw = item['login']['password']
 
         try:
             private_key_id = [
@@ -191,11 +207,18 @@ def add_ssh_keys(
         logging.debug('Private key ID found')
 
         try:
-            ssh_add(session, item['id'], private_key_id, private_key_pw)
+            if args.add and not args.remove:
+                ssh_add(session, item['id'], private_key_id, private_key_pw)
+            if args.remove and not args.add:
+                ssh_remove(session, item['id'], private_key_id, private_key_pw)
         except subprocess.SubprocessError:
             logging.warning('Could not add key to the SSH agent')
 
+        if privatekey_found:
+            break
 
+##################################################
+### Sub-Functions called from within Main Functions
 def ssh_add(session: str, item_id: str, key_id: str, key_pw: Optional[str]) -> None:
     """
     Function to get the key contents from the Bitwarden vault
@@ -241,7 +264,75 @@ def ssh_add(session: str, item_id: str, key_id: str, key_pw: Optional[str]) -> N
         check=True,
     )
 
+def ssh_remove(session: str, item_id: str, key_id: str, key_pw: Optional[str]) -> None:
+    """
+    Function to get the key contents from the Bitwarden vault
+    """
+    logging.debug('Item ID: %s', item_id)
+    logging.debug('Key ID: %s', key_id)
 
+    proc_attachment = subprocess.run(
+        [
+            'bw',
+            'get',
+            'attachment',
+            key_id,
+            '--itemid',
+            item_id,
+            '--raw',
+            '--session',
+            session,
+        ],
+        stdout=subprocess.PIPE,
+        universal_newlines=True,
+        check=True,
+    )
+    ssh_key = str(proc_attachment.stdout)
+
+    if key_pw is None:
+        private_key_object = load_ssh_private_key(ssh_key.encode("ascii"),None)
+    else:
+        private_key_object = load_ssh_private_key(ssh_key.encode("utf-8"),key_pw.encode("utf-8"))
+
+    public_key_object = (private_key_object.public_key()).public_bytes(Encoding.OpenSSH, PublicFormat.OpenSSH).decode("utf-8")
+
+    if key_pw:
+        envdict = dict(
+            os.environ,
+            SSH_ASKPASS=os.path.realpath(__file__),
+            SSH_KEY_PASSPHRASE=key_pw,
+        )
+    else:
+        envdict = dict(os.environ, SSH_ASKPASS_REQUIRE="never")
+
+    logging.debug("Running ssh-add")
+    # CAVEAT: `ssh-add` provides no useful output, even with maximum verbosity
+    subprocess.run(
+        ['ssh-add', '-d', '-'],
+        input=public_key_object,
+        # Works even if ssh-askpass is not installed
+        env=envdict,
+        universal_newlines=True,
+        check=True,
+    )
+
+
+
+@memoize
+def bwcli_version() -> str:
+    """
+    Function to return the version of the Bitwarden CLI
+    """
+    proc_version = subprocess.run(
+        ['bw', '--version'],
+        stdout=subprocess.PIPE,
+        universal_newlines=True,
+        check=True,
+    )
+    return proc_version.stdout
+
+##################################################
+### Main Function!
 if __name__ == '__main__':
 
     def parse_args() -> argparse.Namespace:
@@ -249,6 +340,25 @@ if __name__ == '__main__':
         Function to parse command line arguments
         """
         parser = argparse.ArgumentParser()
+        parser.add_argument(
+            '--add',
+            action='store_true',
+            help='DEFAULT: Add the specified ssh key to ssh-agent.'
+        )
+        parser.add_argument(
+            '--remove',
+            action='store_true',
+            help='Remove the specified ssh key to ssh-agent.'
+        )
+        parser.add_argument(
+            '--entryname',
+            help='Specify the name of the bitwarden entry to add/remove from ssh-agent.'
+        )
+        parser.add_argument(
+            '--assume-keyname',
+            action='store_true',
+            help='Assume the private key file is named identical to bitwarden entry.'
+        )
         parser.add_argument(
             '-d',
             '--debug',
@@ -274,6 +384,11 @@ if __name__ == '__main__':
             help='custom field name where key passphrase is stored',
         )
         parser.add_argument(
+            '--password-as-key-pass',
+            action='store_true',
+            help='Use normal password field as SSH Key Password',
+        )
+        parser.add_argument(
             '-s',
             '--session',
             default='',
@@ -294,8 +409,24 @@ if __name__ == '__main__':
         else:
             loglevel = logging.INFO
 
+        if args.session == "<redacted>":
+            logging.error("Error: You didn't specify a session key in .vscode/launch.json")
+            sys.exit(1)
+
         logging.basicConfig(level=loglevel)
 
+        logging.info("Syncing Bitwarden")
+        subprocess.run(
+            ['bw', 'sync'],
+            stdout=subprocess.PIPE,
+            universal_newlines=True,
+            check=True,
+        )
+
+        if args.add and args.remove:
+            logging.info('ERROR: --add and --remove are specified at the same time. Thats not alloweed.')
+            sys.exit(1)
+        
         try:
             logging.info('Getting Bitwarden session')
             session = get_session(args.session)
@@ -303,16 +434,16 @@ if __name__ == '__main__':
 
             logging.info('Getting folder list')
             folder_id = get_folders(session, args.foldername)
-
             logging.info('Getting folder items')
-            items = folder_items(session, folder_id)
 
+            items = folder_items(session, folder_id)
             logging.info('Attempting to add keys to ssh-agent')
-            add_ssh_keys(session, items, args.customfield, args.passphrasefield)
+            manage_ssh_keys(session, args, items)
         except subprocess.CalledProcessError as error:
             if error.stderr:
                 logging.error('"%s" error: %s', error.cmd[0], error.stderr)
             logging.debug('Error running %s', error.cmd)
+
 
     if os.environ.get('SSH_ASKPASS') and os.environ.get('SSH_ASKPASS') == os.path.realpath(__file__):
         print(os.environ.get('SSH_KEY_PASSPHRASE'))


### PR DESCRIPTION
Hi @joaojacome,

up to now i used KeepassXC, which got synced via nextcloud to all my devices. Now i moved to a "real" selfhosted passwordsafe solution (vaultwarden) and wanted to have the same flexibility as with my KeepassXC setup regarding the ssh key management.

Searching the internet i found your github repo in the bitwarden forum. I tested it and was initially happy, but i missed a bit of the convenience of the KeepassXC sshkey handling. So i added the features i was missing.

New features from me:
- specify entryname instead of iterating over all entries from folder
- remove an entry from ssh-agent
- allow usage of password field as key password
- assume flag which tells the script to use the entryname as the keyname (name of attachment in bitwarden), so no customfield is needed.

Also i merged the solution from #29 from @Weidows before all my development into my new fork, because i needed to specify the session token as the env variable was not always working in my case. Hope this is not a problem regarding merge conflicts.

Additionally i want to extend usage documentation regarding how i use shell aliases so the user is only specifying the parameters he absolutly has to. I could not find the right spot for that part, so it isn't part of this PR yet.

IMPORTANT: I would be relieved if someone could check my python programming. Im literally new to python in general (this is my second python script on which im working in my entire life).

Best regards
hasechris
